### PR TITLE
Removing model name keywords

### DIFF
--- a/catalog/OpenET/OpenET_ENSEMBLE_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_ENSEMBLE_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -248,7 +248,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   'sci:citation': |||
     Melton, F., Huntington, J., Grimm, R., Herring, J., Hall, M., Rollison, D.,
     Erickson, T., Allen, R., Anderson, M., Fisher, J., Kilic, A., Senay, G.,
-    volk, J., Hain, C., Johnson, L., Ruhoff, A., Blanenau, P., Bromley, M.,
+    volk, J., Hain, C., Johnson, L., Ruhoff, A., Blankenau, P., Bromley, M.,
     Carrara, W., Daudert, B., Doherty, C., Dunkerly, C., Friedrichs, M., Guzman,
     A., Halverson, G., Hansen, J., Harding, J., Kang, Y., Ketchum, D., Minor,
     B., Morton, C., Revelle, P., Ortega-Salazar, S., Ott, T., Ozdogon, M., Schull, M., Wang,

--- a/catalog/OpenET/OpenET_GEESEBAL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_GEESEBAL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -63,7 +63,6 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     'landsat_derived',
     'monthly',
     'water',
-    'geesebal'
   ],
   providers: [
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),

--- a/catalog/OpenET/OpenET_SIMS_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_SIMS_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -63,7 +63,6 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     'landsat_derived',
     'monthly',
     'water',
-    'sims'
   ],
   providers: [
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),


### PR DESCRIPTION
We might be able to add these back in once we have other model datasets since the keyword checker doesn't like when a keyword is only used in one dataset.